### PR TITLE
Update sampling and token settings

### DIFF
--- a/WSDM_gemma_2_2b_Seq_Classifier.ipynb
+++ b/WSDM_gemma_2_2b_Seq_Classifier.ipynb
@@ -376,7 +376,7 @@
       "cell_type": "code",
       "source": [
         "# Function to preprocess dataset with smart truncation\n",
-        "def preprocess_data(df, tokenizer, prompt_max_tokens=150, response_max_tokens=350):\n",
+        "def preprocess_data(df, tokenizer, prompt_max_tokens=800, response_max_tokens=1600):\n",
         "    \"\"\"\n",
         "    Preprocess data with smart truncation\n",
         "\n",
@@ -437,7 +437,7 @@
       "cell_type": "code",
       "source": [
         "# Function to tokenize inputs with special tokens\n",
-        "def tokenize_with_special_tokens(df, tokenizer, max_length=512):\n",
+        "def tokenize_with_special_tokens(df, tokenizer, max_length=4096):\n",
         "    \"\"\"\n",
         "    Tokenize inputs with special tokens\n",
         "\n",
@@ -500,7 +500,7 @@
       "cell_type": "code",
       "source": [
         "# Function to create HuggingFace datasets\n",
-        "def create_hf_datasets(train_df, val_df, test_df, tokenizer, max_length=512):\n",
+        "def create_hf_datasets(train_df, val_df, test_df, tokenizer, max_length=4096):\n",
         "    \"\"\"\n",
         "    Create HuggingFace datasets from DataFrames\n",
         "\n",
@@ -867,7 +867,7 @@
       "cell_type": "code",
       "source": [
         "# 2. Load and sample data\n",
-        "data = load_data(\"/content/train.parquet\", sample_percentage=100)"
+        "data = load_data(\"/content/train.parquet\", sample_percentage=5)"
       ],
       "metadata": {
         "trusted": true,
@@ -976,7 +976,7 @@
       "source": [
         "# 6. Create HuggingFace datasets\n",
         "hf_train_dataset, hf_val_dataset, hf_test_dataset = create_hf_datasets(\n",
-        "    train_df, val_df, test_df, tokenizer, max_length=512\n",
+        "    train_df, val_df, test_df, tokenizer, max_length=4096\n",
         ")"
       ],
       "metadata": {


### PR DESCRIPTION
## Summary
- sample only 5% of training data
- increase prompt and response token limits
- extend tokenization length

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68644fe5b9108330b3f6f4b0a361cc6b